### PR TITLE
尝试为MySQL添加SSL支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ table: users
 #    user: root
 #    password: pwd
 #    database: e5sub
+# ssl_mode and enabled_tls_protocols are only required when the database requires a SSL connection (e.g. TiDB Cloud)
+#    ssl_mode: PREFERRED
+#    enabled_tls_protocols: TLSv1.2,TLSv1.3
 sqlite:
    db: data.db
 ```

--- a/README.md
+++ b/README.md
@@ -130,9 +130,8 @@ table: users
 #    user: root
 #    password: pwd
 #    database: e5sub
-# ssl_mode and enabled_tls_protocols are only required when the database requires a SSL connection (e.g. TiDB Cloud)
+# ssl_mode is only required when the database requires a SSL connection (e.g. TiDB Cloud)
 #    ssl_mode: PREFERRED
-#    enabled_tls_protocols: TLSv1.2,TLSv1.3
 sqlite:
    db: data.db
 ```

--- a/README_zhCN.md
+++ b/README_zhCN.md
@@ -126,9 +126,8 @@ table: users
 #    user: root
 #    password: pwd
 #    database: e5sub
-# ssl_mode和enabled_tls_protocols仅在数据库需要SSL链接时才需要配置（如连接TiDB Cloud）
+# ssl_mode仅在数据库需要SSL链接时才需要配置（如连接TiDB Cloud）
 #    ssl_mode: PREFERRED
-#    enabled_tls_protocols: TLSv1.2,TLSv1.3
 sqlite:
    db: data.db
 ```

--- a/README_zhCN.md
+++ b/README_zhCN.md
@@ -126,6 +126,9 @@ table: users
 #    user: root
 #    password: pwd
 #    database: e5sub
+# ssl_mode和enabled_tls_protocols仅在数据库需要SSL链接时才需要配置（如连接TiDB Cloud）
+#    ssl_mode: PREFERRED
+#    enabled_tls_protocols: TLSv1.2,TLSv1.3
 sqlite:
    db: data.db
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -50,11 +50,13 @@ func Init() {
 	switch DB {
 	case "mysql":
 		Mysql = mysqlConfig{
-			Host:     viper.GetString("mysql.host"),
-			Port:     viper.GetInt("mysql.port"),
-			User:     viper.GetString("mysql.user"),
-			Password: viper.GetString("mysql.password"),
-			DB:       viper.GetString("mysql.database"),
+			Host:                viper.GetString("mysql.host"),
+			Port:                viper.GetInt("mysql.port"),
+			User:                viper.GetString("mysql.user"),
+			Password:            viper.GetString("mysql.password"),
+			DB:                  viper.GetString("mysql.database"),
+			SSLMode:             viper.GetString("mysql.ssl_mode"),
+			EnabledTLSProtocols: viper.GetString("mysql.enabled_tls_protocols"),
 		}
 	case "sqlite":
 		Sqlite = sqliteConfig{

--- a/config/model.go
+++ b/config/model.go
@@ -19,9 +19,11 @@ type sqliteConfig struct {
 	DB string `json:"db,omitempty"`
 }
 type mysqlConfig struct {
-	Host     string `json:"host,omitempty"`
-	Port     int    `json:"port,omitempty"`
-	User     string `json:"user,omitempty"`
-	Password string `json:"password,omitempty"`
-	DB       string `json:"db,omitempty"`
+	Host                string `json:"host,omitempty"`
+	Port                int    `json:"port,omitempty"`
+	User                string `json:"user,omitempty"`
+	Password            string `json:"password,omitempty"`
+	DB                  string `json:"db,omitempty"`
+	SSLMode             string `json:"ssl_mode,omitempty"`
+	EnabledTLSProtocols string `json:"enabled_tls_protocols,omitempty"`
 }

--- a/db/db.go
+++ b/db/db.go
@@ -30,11 +30,7 @@ func Init() {
 		)
 
 		if config.Mysql.SSLMode != "" {
-			dsn += "&sslMode=" + config.Mysql.SSLMode
-
-			if config.Mysql.EnabledTLSProtocols != "" {
-				dsn += "&enabledTLSProtocols=" + config.Mysql.EnabledTLSProtocols
-			}
+			dsn += "&tls=" + config.Mysql.SSLMode
 		}
 
 		dial = mysql.Open(dsn)

--- a/db/db.go
+++ b/db/db.go
@@ -21,13 +21,23 @@ func Init() {
 
 	switch config.DB {
 	case "mysql":
-		dial = mysql.Open(fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local",
+		var dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Local",
 			config.Mysql.User,
 			config.Mysql.Password,
 			config.Mysql.Host,
 			config.Mysql.Port,
 			config.Mysql.DB,
-		))
+		)
+
+		if config.Mysql.SSLMode != "" {
+			dsn += "&sslMode=" + config.Mysql.SSLMode
+
+			if config.Mysql.EnabledTLSProtocols != "" {
+				dsn += "&enabledTLSProtocols=" + config.Mysql.EnabledTLSProtocols
+			}
+		}
+
+		dial = mysql.Open(dsn)
 	case "sqlite":
 		dial = sqlite.Open(config.Sqlite.DB)
 	}


### PR DESCRIPTION
因为TiDB Cloud强制使用SSL连接，故尝试为E5SubBot添加MySQL的SSL支持。
但是自测并没有通过SSL连接，貌似gorm不支持通过SSL连接MySQL？
总之先提交一版，然后可以的话我们一起看看怎么实现它。